### PR TITLE
Cleans up variables in widget method

### DIFF
--- a/class-plugin-canary-widget.php
+++ b/class-plugin-canary-widget.php
@@ -46,5 +46,10 @@ class Plugin_Canary_Widget {
 
 		// Use the template to render widget output.
 		require_once( 'widget.php' );
+
+		// Clean up.
+		$plugin_data = null;
+		$update_data = null;
+
 	}
 }


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
The widget method in the class is being flagged because we populate a variable, `$plugin_data` that is never explicitly handled (because we then require the template, which is where the handling takes place.

I'm not sure of the best way around this, but I can get the violation to go away by explicitly setting variables to `null` at the end of the method.

#### How can a reviewer manually see the effects of these changes?
Look at the Travis and CodeClimate output

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
